### PR TITLE
Added empty data check

### DIFF
--- a/entropy.go
+++ b/entropy.go
@@ -57,6 +57,11 @@ func Frequency(data []byte, chunkSize int) float64 {
 }
 
 func IsRandom(data []byte) bool {
+	// Check for empty data
+	if len(data) == 0 {
+		return false
+	}
+	
 	// These vars may be changed to adjust randomness measurement
 	var tuple = 8
 	var chunkSize = 256


### PR DESCRIPTION
Avoids `runtime error: index out of range` error in `cryptostalker`.
See https://github.com/unixist/cryptostalker/issues/20 for more information.